### PR TITLE
Handle wash_out changed XML format

### DIFF
--- a/lib/qbwc/controller.rb
+++ b/lib/qbwc/controller.rb
@@ -1,3 +1,6 @@
+require 'wash_out/version'
+include WashOut
+
 module QBWC
   module Controller
     def self.included(base)
@@ -9,48 +12,46 @@ module QBWC
 
         # wash_out changed the format of app/views/wash_with_soap/rpc/response.builder in commit
         # https://github.com/inossidabile/wash_out/commit/24a77f4a3d874562732c6e8c3a30e8defafea7cb
-        require 'wash_out/version'
-        include WashOut
-        tns_prefix = (Gem::Version.new(WashOut::VERSION) < Gem::Version.new('0.9.1') ? 'tns:' : '')
+        wash_out_xml_namespace = (Gem::Version.new(WashOut::VERSION) < Gem::Version.new('0.9.1') ? 'tns:' : '')
 
         soap_action 'serverVersion', :to => :server_version,
                     :return => {'tns:serverVersionResult' => :string},
-                    :response_tag => "#{tns_prefix}serverVersionResponse"
+                    :response_tag => "#{wash_out_xml_namespace}serverVersionResponse"
 
         soap_action 'clientVersion', :to => :client_version,
                     :args   => {:strVersion => :string},
                     :return => {'tns:clientVersionResult' => :string},
-                    :response_tag => "#{tns_prefix}clientVersionResponse"
+                    :response_tag => "#{wash_out_xml_namespace}clientVersionResponse"
 
         soap_action 'authenticate',
                     :args   => {:strUserName => :string, :strPassword => :string},
                     :return => {'tns:authenticateResult' => StringArray},
-                    :response_tag => "#{tns_prefix}authenticateResponse"
+                    :response_tag => "#{wash_out_xml_namespace}authenticateResponse"
 
         soap_action 'sendRequestXML', :to => :send_request,
                     :args   => {:ticket => :string, :strHCPResponse => :string, :strCompanyFilename => :string, :qbXMLCountry => :string, :qbXMLMajorVers => :string, :qbXMLMinorVers => :string},
                     :return => {'tns:sendRequestXMLResult' => :string},
-                    :response_tag => "#{tns_prefix}sendRequestXMLResponse"
+                    :response_tag => "#{wash_out_xml_namespace}sendRequestXMLResponse"
 
         soap_action 'receiveResponseXML', :to => :receive_response,
                     :args   => {:ticket => :string, :response => :string, :hresult => :string, :message => :string},
                     :return => {'tns:receiveResponseXMLResult' => :integer},
-                    :response_tag => "#{tns_prefix}receiveResponseXMLResponse"
+                    :response_tag => "#{wash_out_xml_namespace}receiveResponseXMLResponse"
 
         soap_action 'closeConnection', :to => :close_connection,
                     :args   => {:ticket => :string},
                     :return => {'tns:closeConnectionResult' => :string},
-                    :response_tag => "#{tns_prefix}closeConnectionResponse"
+                    :response_tag => "#{wash_out_xml_namespace}closeConnectionResponse"
 
         soap_action 'connectionError', :to => :connection_error,
                     :args   => {:ticket => :string, :hresult => :string, :message => :string},
                     :return => {'tns:connectionErrorResult' => :string},
-                    :response_tag => "#{tns_prefix}connectionErrorResponse"
+                    :response_tag => "#{wash_out_xml_namespace}connectionErrorResponse"
 
         soap_action 'getLastError', :to => :get_last_error,
                     :args   => {:ticket => :string},
                     :return => {'tns:getLastErrorResult' => :string},
-                    :response_tag => "#{tns_prefix}getLastErrorResponse"
+                    :response_tag => "#{wash_out_xml_namespace}getLastErrorResponse"
       end
     end
 


### PR DESCRIPTION
I believe this commit (not yet in current stable gem) has altered the expected XML that qbwc should pass to it: https://github.com/inossidabile/wash_out/commit/24a77f4a3d874562732c6e8c3a30e8defafea7cb. AFAICT this is a breaking change when qbwc uses edge wash_out. 

I'd appreciate another set of eyes on this.
