### PR TITLE
Relax 1000-char limit on qbwc_sessions.pending_jobs

### DIFF
--- a/lib/generators/qbwc/install/templates/db/migrate/create_qbwc_sessions.rb
+++ b/lib/generators/qbwc/install/templates/db/migrate/create_qbwc_sessions.rb
@@ -8,7 +8,7 @@ class CreateQbwcSessions < ActiveRecord::Migration
       t.string :current_job
       t.string :iterator_id
       t.string :error, :limit => 1000
-      t.string :pending_jobs, :limit => 1000, :null => false, :default => ''
+      t.text :pending_jobs, :null => false, :default => ''
 
       t.timestamps :null => false
     end


### PR DESCRIPTION
AFAICT there is no need for a limit on the size of column qbwc_sessions.pending_jobs. I suspect that the existing 1000-char limit may have been a quick-and-dirty technique to extend beyond a [Rails implicit limit of 255 chars](http://stackoverflow.com/questions/8694273/changing-a-column-type-to-longer-strings-in-rails/8694483#8694483). Fixes #75.

References:
* http://api.rubyonrails.org/classes/ActiveRecord/ConnectionAdapters/TableDefinition.html#method-i-column
* http://www.wetware.co.nz/2009/04/rails-migration-data-types-mysql-postgresql-sqlite/