### PR TITLE
Courtesy changes to aid migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,34 @@
+
+# Change Log
+
+## [1.0.0](https://github.com/qbwc/qbwc/tree/2.0.4) (2016-12-04)
+[Full Changelog](https://github.com/qbwc/qbwc/compare/2.0.3...2.0.4)
+
+**Upgrading:**
+
+Upgrading from previous versions requires running new migrations.
+
+Run the generator:
+
+`rails generate qbwc:install`
+
+Then the migrations:
+
+`rake db:migrate`
+`rake RAILS_ENV=test db:migrate`
+
+In production, ensure that no jobs are queued, then:
+`rake RAILS_ENV=production db:migrate`
+
+**Fixed bugs:**
+
+- Placeholder [\#156](https://github.com/qbwc/qbwc/issues/156)
+
+**Closed issues:**
+
+- Placeholder [\#129](https://github.com/qbwc/qbwc/issues/129)
+
+**Merged pull requests:**
+
+- Placeholder [\#235](https://github.com/qbwc/qbwc/pull/235) ([mamnun](https://github.com/mamnun))
+

--- a/README.md
+++ b/README.md
@@ -29,22 +29,6 @@ Open `config/initializers/qbwc.rb` and check the settings there. (Re-)start your
 Quickbooks *requires* HTTPS connections when connecting to remote machines. [ngrok](https://ngrok.com/) may be useful to fulfill this requirement.
 
 
-## Upgrading from prior versions
-Upgrading to the current version requires running new migrations.
-
-Run the generator:
-
-`rails generate qbwc:install`
-
-Then the migrations:
-
-`rake db:migrate`
-`rake RAILS_ENV=test db:migrate`
-
-In production, ensure that no jobs are queued, then:
-`rake RAILS_ENV=production db:migrate`
-
-
 ### Authentication and multiple company files ###
 
 If connecting to more than one company file or if you want different logins for different users, you can configure QBWC authentication. This is a `Proc` in `config/initializers/qbwc.rb` that accepts the username and password and returns the path to the QuickBooks company file to access:

--- a/README.md
+++ b/README.md
@@ -29,6 +29,18 @@ Open `config/initializers/qbwc.rb` and check the settings there. (Re-)start your
 Quickbooks *requires* HTTPS connections when connecting to remote machines. [ngrok](https://ngrok.com/) may be useful to fulfill this requirement.
 
 
+## Upgrading from prior versions
+Version 1.0.0 requires rerunning migrations.
+
+Run the generator:
+
+`rails generate qbwc:install`
+
+Then the migrations:
+
+`rake db:migrate`
+
+
 ### Authentication and multiple company files ###
 
 If connecting to more than one company file or if you want different logins for different users, you can configure QBWC authentication. This is a `Proc` in `config/initializers/qbwc.rb` that accepts the username and password and returns the path to the QuickBooks company file to access:

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Quickbooks *requires* HTTPS connections when connecting to remote machines. [ngr
 
 
 ## Upgrading from prior versions
-Version 1.0.0 requires rerunning migrations.
+Upgrading to the current version requires running new migrations.
 
 Run the generator:
 
@@ -39,6 +39,10 @@ Run the generator:
 Then the migrations:
 
 `rake db:migrate`
+`rake RAILS_ENV=test db:migrate`
+
+In production, ensure that no jobs are queued, then:
+`rake RAILS_ENV=production db:migrate`
 
 
 ### Authentication and multiple company files ###

--- a/lib/generators/qbwc/install/install_generator.rb
+++ b/lib/generators/qbwc/install/install_generator.rb
@@ -12,6 +12,10 @@ module QBWC
       source_root File.expand_path('../templates', __FILE__)
       argument :controller_name, :type => :string, :default => 'qbwc'
       
+      def routes_rb
+         "config/routes.rb"
+      end
+
       def copy_config
          template('config/qbwc.rb', "config/initializers/qbwc.rb")
       end
@@ -31,10 +35,24 @@ module QBWC
         ::ActiveRecord::Generators::Base.next_migration_number(dirname)
       end
 
+     def route1
+        "wash_out :#{controller_name}"
+     end
+
+     def route2
+        "get '#{controller_name}/qwc' => '#{controller_name}#qwc'"
+     end
+
+     def route3
+        "get '#{controller_name}/action' => '#{controller_name}#_generate_wsdl'"
+     end
+
+     # Idempotent routes inspired by https://github.com/thoughtbot/administrate/issues/232
+     # Idempotent routes fixed permanently by https://github.com/rails/rails/issues/22082
      def setup_routes
-        route("wash_out :#{controller_name}")
-        route("get '#{controller_name}/qwc' => '#{controller_name}#qwc'")
-        route("get '#{controller_name}/action' => '#{controller_name}#_generate_wsdl'")
+        route(route1) unless File.new(routes_rb).read.include?(route1)
+        route(route2) unless File.new(routes_rb).read.include?(route2)
+        route(route3) unless File.new(routes_rb).read.include?(route3)
       end
       
     end

--- a/lib/generators/qbwc/install/install_generator.rb
+++ b/lib/generators/qbwc/install/install_generator.rb
@@ -23,6 +23,8 @@ module QBWC
       def active_record
         migration_template 'db/migrate/create_qbwc_jobs.rb',     'db/migrate/create_qbwc_jobs.rb'
         migration_template 'db/migrate/create_qbwc_sessions.rb', 'db/migrate/create_qbwc_sessions.rb'
+        migration_template 'db/migrate/index_qbwc_jobs.rb',      'db/migrate/index_qbwc_jobs.rb'
+        migration_template 'db/migrate/change_request_index.rb', 'db/migrate/change_request_index.rb'
       end
 
       def self.next_migration_number(dirname)

--- a/lib/generators/qbwc/install/templates/db/migrate/change_request_index.rb
+++ b/lib/generators/qbwc/install/templates/db/migrate/change_request_index.rb
@@ -1,0 +1,5 @@
+class ChangeRequestIndex < ActiveRecord::Migration
+  def change
+    change_column :qbwc_jobs, :request_index, :text
+  end
+end

--- a/lib/generators/qbwc/install/templates/db/migrate/create_qbwc_jobs.rb
+++ b/lib/generators/qbwc/install/templates/db/migrate/create_qbwc_jobs.rb
@@ -5,13 +5,11 @@ class CreateQbwcJobs < ActiveRecord::Migration
       t.string :company, :limit => 1000
       t.string :worker_class, :limit => 100
       t.boolean :enabled, :null => false, :default => false
-      t.text :request_index
+      t.integer :request_index, :null => false, :default => 0
       t.text :requests
       t.boolean :requests_provided_when_job_added, :null => false, :default => false
       t.text :data
       t.timestamps :null => false
     end
-    add_index :qbwc_jobs, :name, unique: true
-    add_index :qbwc_jobs, :company
   end
 end

--- a/lib/generators/qbwc/install/templates/db/migrate/index_qbwc_jobs.rb
+++ b/lib/generators/qbwc/install/templates/db/migrate/index_qbwc_jobs.rb
@@ -1,0 +1,6 @@
+class IndexQbwcJobs < ActiveRecord::Migration
+  def change
+    add_index :qbwc_jobs, :name, unique: true
+    add_index :qbwc_jobs, :company
+  end
+end

--- a/lib/qbwc.rb
+++ b/lib/qbwc.rb
@@ -93,7 +93,7 @@ module QBWC
       storage_module::Job.delete_job_with_name(name)
     end
 
-    def pending_jobs(company, session)
+    def pending_jobs(company, session = QBWC::Session.get)
       js = jobs
       QBWC.logger.info "#{js.length} jobs exist, checking for pending jobs for company '#{company}'."
       storage_module::Job.sort_in_time_order(js.select {|job| job.company == company && job.pending?(session)})

--- a/lib/qbwc/active_record/job.rb
+++ b/lib/qbwc/active_record/job.rb
@@ -60,7 +60,7 @@ class QBWC::ActiveRecord::Job < QBWC::Job
     find_ar_job.where(:enabled => true).exists?
   end
 
-  def requests(session)
+  def requests(session = QBWC::Session.get)
     @requests = find_ar_job.pluck(:requests).first
     super
   end

--- a/lib/qbwc/job.rb
+++ b/lib/qbwc/job.rb
@@ -97,7 +97,7 @@ class QBWC::Job
     @requests_provided_when_job_added = value
   end
 
-  def next_request(session)
+  def next_request(session = QBWC::Session.get)
     reqs = requests session
 
     # Generate and save the requests to run when starting the job.

--- a/lib/qbwc/session.rb
+++ b/lib/qbwc/session.rb
@@ -5,7 +5,7 @@ class QBWC::Session
 
   @@session = nil
 
-	def self.get(ticket)
+	def self.get(ticket = nil)
 		@@session
 	end
 

--- a/test/qbwc/integration/job_management_test.rb
+++ b/test/qbwc/integration/job_management_test.rb
@@ -3,6 +3,9 @@ require 'test_helper.rb'
 
 class JobManagementTest < ActionDispatch::IntegrationTest
 
+  REQUESTS_AS_HASH   = {:customer_query_rq => {:full_name => 'Quincy Bob William Carlos'}}
+  REQUESTS_AS_STRING = QBWC_CUSTOMER_ADD_RQ
+
   def setup
     JobManagementTest.app = Rails.application
     Rails.logger = Logger.new('/dev/null')  # or STDOUT
@@ -16,6 +19,26 @@ class JobManagementTest < ActionDispatch::IntegrationTest
 
     # Overwrite existing job
     QBWC.add_job(:integration_test, true, 'my-company', QBWC::Worker)
+    assert_equal 1, QBWC.jobs.length
+  end
+
+  test "add_job requests as hash" do
+    QBWC.add_job(:integration_test, true, '', QBWC::Worker, REQUESTS_AS_HASH)
+    assert_equal 1, QBWC.jobs.length
+  end
+
+  test "add_job requests as array of hashes" do
+    QBWC.add_job(:integration_test, true, '', QBWC::Worker, [REQUESTS_AS_HASH])
+    assert_equal 1, QBWC.jobs.length
+  end
+
+  test "add_job requests as string" do
+    QBWC.add_job(:integration_test, true, '', QBWC::Worker, REQUESTS_AS_STRING)
+    assert_equal 1, QBWC.jobs.length
+  end
+
+  test "add_job requests as array of strings" do
+    QBWC.add_job(:integration_test, true, '', QBWC::Worker, [REQUESTS_AS_STRING])
     assert_equal 1, QBWC.jobs.length
   end
 
@@ -73,7 +96,7 @@ class JobManagementTest < ActionDispatch::IntegrationTest
 
   class DeleteJobWorker < QBWC::Worker
     def requests(job, session, data)
-      {:customer_query_rq => {:full_name => 'Quincy Bob William Carlos'}}
+      REQUESTS_AS_HASH
     end
 
     def handle_response(resp, session, job, request, data)

--- a/test/qbwc/integration/job_management_test.rb
+++ b/test/qbwc/integration/job_management_test.rb
@@ -25,6 +25,12 @@ class JobManagementTest < ActionDispatch::IntegrationTest
     assert_empty QBWC.pending_jobs('another-company', @session)
   end
 
+  test "pending_jobs with default session" do
+    QBWC.add_job(:integration_test, true, 'my-company', QBWC::Worker)
+    assert_equal 1, QBWC.pending_jobs('my-company').length
+    assert_empty QBWC.pending_jobs('another-company')
+  end
+
   test "pending_jobs_disabled" do
     QBWC.add_job(:integration_test, false, 'my-company', QBWC::Worker)
     assert_empty QBWC.pending_jobs('my-company', @session)

--- a/test/qbwc/integration/job_management_test.rb
+++ b/test/qbwc/integration/job_management_test.rb
@@ -42,6 +42,30 @@ class JobManagementTest < ActionDispatch::IntegrationTest
     assert_equal 1, QBWC.jobs.length
   end
 
+  test "requests" do
+    job = QBWC.add_job(:integration_test, true, '', QBWC::Worker)
+    session = QBWC::Session.new('foo', '')
+    assert_nil job.requests(session)
+  end
+
+  test "requests with default session" do
+    job = QBWC.add_job(:integration_test, true, '', QBWC::Worker)
+    session = QBWC::Session.new('foo', '')
+    assert_nil job.requests
+  end
+
+  test "next_request" do
+    job = QBWC.add_job(:integration_test, true, '', QBWC::Worker)
+    session = QBWC::Session.new('foo', '')
+    assert_nil job.next_request(session)
+  end
+
+  test "next_request with default session" do
+    job = QBWC.add_job(:integration_test, true, '', QBWC::Worker)
+    session = QBWC::Session.new('foo', '')
+    assert_nil job.next_request
+  end
+
   test "pending_jobs" do
     QBWC.add_job(:integration_test, true, 'my-company', QBWC::Worker)
     assert_equal 1, QBWC.pending_jobs('my-company', @session).length

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -41,8 +41,12 @@ module QbwcTestApplication
     end
     ActiveRecord::Base.establish_connection(:adapter => "sqlite3", :database => ":memory:")
     require '../qbwc/lib/generators/qbwc/install/templates/db/migrate/create_qbwc_jobs'
+    require '../qbwc/lib/generators/qbwc/install/templates/db/migrate/index_qbwc_jobs'
+    require '../qbwc/lib/generators/qbwc/install/templates/db/migrate/change_request_index'
     require '../qbwc/lib/generators/qbwc/install/templates/db/migrate/create_qbwc_sessions'
     ActiveRecord::Migration.run(CreateQbwcJobs)
+    ActiveRecord::Migration.run(IndexQbwcJobs)
+    ActiveRecord::Migration.run(ChangeRequestIndex)
     ActiveRecord::Migration.run(CreateQbwcSessions)
     QBWC.configure do |c|
       c.username = QBWC_USERNAME


### PR DESCRIPTION
This PR provides various changes to ease the migration path from users already using a prior version of qbwc:
* Make session an optional argument, defaulting to `QBWC::Session.get`
* Separate out new migrations, allowing incremental changes to existing schema
* Draft instructions for migrating to this version

Other notes:
* You will want to bump major version when releasing, since this version includes breaking changes
* Rerunning `rails generate qbwc:install` is not fully idempotent

cc @bkroeker 