### PR TITLE
Fix handling of empty QBXML responses

### DIFF
--- a/lib/qbwc/session.rb
+++ b/lib/qbwc/session.rb
@@ -81,7 +81,9 @@ class QBWC::Session
     begin
       QBWC.logger.info 'Parsing response.'
       unless qbxml_response.nil?
-        response = QBWC.parser.from_qbxml(qbxml_response)["qbxml"]["qbxml_msgs_rs"].except("xml_attributes")
+        response = QBWC.parser.from_qbxml(qbxml_response)["qbxml"]["qbxml_msgs_rs"]
+        response = Qbxml::Hash.new if response == ""
+        response = response.except("xml_attributes")
         response = response[response.keys.first]
         parse_response_header(response)
       end

--- a/lib/qbwc/session.rb
+++ b/lib/qbwc/session.rb
@@ -82,9 +82,10 @@ class QBWC::Session
       QBWC.logger.info 'Parsing response.'
       unless qbxml_response.nil?
         response = QBWC.parser.from_qbxml(qbxml_response)["qbxml"]["qbxml_msgs_rs"]
-        response = Qbxml::Hash.new if response == ""
-        response = response.except("xml_attributes")
-        response = response[response.keys.first]
+        if response.respond_to?(:except)
+          response = response.except("xml_attributes")
+          response = response[response.keys.first]
+        end
         parse_response_header(response)
       end
       self.current_job.process_response(qbxml_response, response, self, iterator_id.blank?) unless self.current_job.nil?

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -106,7 +106,6 @@ QBWC_BAD_EMPTY_RESPONSE = "<?xml version=\"1.0\"?>\r
     <?qbxml version=\"7.0\"?>\r
     <QBXML>\r
       <QBXMLMsgsRs />\r
-      </QBXMLMsgsRs>\r
     </QBXML>\r"
 
 QBWC_CUSTOMER_ADD_RQ = "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -14,6 +14,8 @@ require 'qbwc'
 require 'qbwc/controller'
 require 'qbwc/active_record'
 
+$VERBOSE = nil
+
 COMPANY = 'c:\\QuickBooks\MyFile.QBW'
 QBWC_USERNAME = 'myUserName'
 QBWC_PASSWORD = 'myPassword'
@@ -97,6 +99,13 @@ QBWC_EMPTY_RESPONSE = "<?xml version=\"1.0\"?>\r
     <?qbxml version=\"7.0\"?>\r
     <QBXML>\r
       <QBXMLMsgsRs onError=\"stopOnError\">\r
+      </QBXMLMsgsRs>\r
+    </QBXML>\r"
+
+QBWC_BAD_EMPTY_RESPONSE = "<?xml version=\"1.0\"?>\r
+    <?qbxml version=\"7.0\"?>\r
+    <QBXML>\r
+      <QBXMLMsgsRs />\r
       </QBXMLMsgsRs>\r
     </QBXML>\r"
 


### PR DESCRIPTION
An empty QBXML response of the form 

```
<?xml version=\"1.0\"?>
    <?qbxml version=\"7.0\"?>
    <QBXML>
      <QBXMLMsgsRs />
    </QBXML>

```

fails to parse and generates the error message:

An error occured in QBWC::Session: undefined method `except' for "":String

Apparently, that syntax causes the QBXML parser to generate an empty String rather than a Qbxml::Hash, so the fix is to check for an empty string and replace it with a new (empty) Qbxml::Hash and continue processing. 
