### PR TITLE
Log qbxml_response closer to the top of #process_response

### DIFF
--- a/lib/qbwc/job.rb
+++ b/lib/qbwc/job.rb
@@ -23,10 +23,10 @@ class QBWC::Job
 
   def process_response(qbxml_response, response, session, advance)
     QBWC.logger.info "Processing response."
+    QBWC.logger.info "Job '#{name}' received response: '#{qbxml_response}'." if QBWC.log_requests_and_responses
     request_list = requests(session)
     completed_request = request_list[request_index(session)] if request_list
     advance_next_request(session) if advance
-    QBWC.logger.info "Job '#{name}' received response: '#{qbxml_response}'." if QBWC.log_requests_and_responses
     worker.handle_response(response, session, self, completed_request, data)
   end
 


### PR DESCRIPTION
This simple commit moves the debug logging in QBWC::Job#process_response (when QBWC.log_requests_and_responses is enabled) closer to the top of the method.  I found this useful when debugging the empty response issue (fixed in PR #89) because that bug was generating an exception in QBWC::Session#response= and the response was thus not getting logged.

Note that I wasn't sure how one would easily test the logging, so there's no associated test.