### PR TITLE
Clarify documentation regarding top-level tag in response hash

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ end
 ```
 
 
-Use the [Onscreen Reference for Intuit Software Development Kits](https://developer-static.intuit.com/qbSDK-current/Common/newOSR/index.html) (use Format: qbXML) to see request and response formats to use in your jobs. Use underscored, lowercased versions of all tags (e.g. `customer_query_rq`, not `CustomerQueryRq`).
+Use the [Onscreen Reference for Intuit Software Development Kits](https://developer-static.intuit.com/qbSDK-current/Common/newOSR/index.html) (use Format: qbXML) to see request and response formats to use in your jobs. Use underscored, lowercased versions of all tags (e.g. `customer_query_rq`, not `CustomerQueryRq`).  Note that while requests include the top-level tag (e.g. `customer_query_rq`), the response hash passed to `QBWC::Worker#handle_response` does not include a corresponding top-level tag such as `customer_query_rs` (despite it being in the actual QBXML and shown in the OSR).
 
 ### Defining requests outside of a worker ###
 


### PR DESCRIPTION
One of the things I was initially confused by is that there appears to be an inconsistency in how request and response hashes are built --- whereas when sending a request, the top-level _rq tag is included as the top-level key (e.g. `customer_query_rq`), the corresponding response hash (as passed to `QBWC::Worker#handle_response`) does not include the _rs tag shown in the actual QBXML.

While I might classify that as a bug in the API, changing it would break existing code, so this PR at least clarifies the documentation by making explicit what was already implied in code example.