### PR TITLE
Use around_action style callbacks in place of around_filter

### DIFF
--- a/lib/qbwc/controller.rb
+++ b/lib/qbwc/controller.rb
@@ -10,9 +10,9 @@ module QBWC
     def self.included(base)
       base.class_eval do
         soap_service
-        skip_before_filter :_authenticate_wsse, :_map_soap_parameters, :only => :qwc
-        before_filter :get_session, :except => [:qwc, :authenticate, :_generate_wsdl]
-        after_filter :save_session, :except => [:qwc, :authenticate, :_generate_wsdl, :close_connection, :connection_error]
+        skip_before_action :_authenticate_wsse, :_map_soap_parameters, :only => :qwc
+        before_action :get_session, :except => [:qwc, :authenticate, :_generate_wsdl]
+        after_action :save_session, :except => [:qwc, :authenticate, :_generate_wsdl, :close_connection, :connection_error]
 
         # wash_out changed the format of app/views/wash_with_soap/rpc/response.builder in commit
         # https://github.com/inossidabile/wash_out/commit/24a77f4a3d874562732c6e8c3a30e8defafea7cb


### PR DESCRIPTION
The following deprecation warnings appear in the development log after running the Web Connector:

```
DEPRECATION` WARNING: before_filter is deprecated and will be removed in Rails 5.1. Use before_action instead. (called from block in included at /home/webuser/.rvm/gems/ruby-2.3.1/bundler/gems/qbwc-e09e655b589c/lib/qbwc/controller.rb:12)
DEPRECATION WARNING: before_filter is deprecated and will be removed in Rails 5.1. Use before_action instead. (called from block in included at /home/webuser/.rvm/gems/ruby-2.3.1/bundler/gems/qbwc-e09e655b589c/lib/qbwc/controller.rb:12)
DEPRECATION WARNING: skip_before_filter is deprecated and will be removed in Rails 5.1. Use skip_before_action instead. (called from block in included at /home/webuser/.rvm/gems/ruby-2.3.1/bundler/gems/qbwc-e09e655b589c/lib/qbwc/controller.rb:12)
DEPRECATION WARNING: skip_before_filter is deprecated and will be removed in Rails 5.1. Use skip_before_action instead. (called from block in included at /home/webuser/.rvm/gems/ruby-2.3.1/bundler/gems/qbwc-e09e655b589c/lib/qbwc/controller.rb:13)
DEPRECATION WARNING: before_filter is deprecated and will be removed in Rails 5.1. Use before_action instead. (called from block in included at /home/webuser/.rvm/gems/ruby-2.3.1/bundler/gems/qbwc-e09e655b589c/lib/qbwc/controller.rb:14)
DEPRECATION WARNING: after_filter is deprecated and will be removed in Rails 5.1. Use after_action instead. (called from block in included at /home/webuser/.rvm/gems/ruby-2.3.1/bundler/gems/qbwc-e09e655b589c/lib/qbwc/controller.rb:15)
Processing by QbwcController#server_version as HTML
  Parameters: {"defaults"=>{"controller"=>"qbwc", `"action"=>"_action"}}
```

I couldn't get the initial `rake test` to pass (prior to making changes), so I wasn't sure how to proceed with adding or modifying existing tests to ensure that those would pass. (This is my first attempt at an "open source pull request", so a lot of this is still super new to me!).  