### PR TITLE
Relax 1000-char limit on qbwc_sessions.pending_jobs

### DIFF
--- a/lib/generators/qbwc/install/templates/db/migrate/create_qbwc_sessions.rb
+++ b/lib/generators/qbwc/install/templates/db/migrate/create_qbwc_sessions.rb
@@ -8,7 +8,7 @@ class CreateQbwcSessions < ActiveRecord::Migration
       t.string :current_job
       t.string :iterator_id
       t.string :error, :limit => 1000
-      t.string :pending_jobs, :limit => 1000, :null => false, :default => ''
+      t.text :pending_jobs, :null => false, :default => ''
 
       t.timestamps :null => false
     end


### PR DESCRIPTION
PR https://github.com/qbwc/qbwc/pull/76 appears to have been lost (presumably due to some [merge hiccup](https://github.com/qbwc/qbwc/issues/88)?). This PR restores that change.

Unfortunately, there doesn't seem to be an easy way to construct an appropriate test (similar to "authenticate with jobs"), because SQLite (used in the test suite) [doesn't enforce the length of a VARCHAR](https://sqlite.org/faq.html#q9). (there is a way to [set maximum string length at run-time](https://www.sqlite.org/limits.html#max_length) using the [sqlite3_limit interface](https://www.sqlite.org/c3ref/limit.html) but this seems to be overkill for this case).

Furthermore, I am unable to reproduce the original failure https://github.com/qbwc/qbwc/issues/75 when using Rails 4.2.7.1 + PostgreSQL, possibly because in Rails 4.2, [the PostgreSQL and SQLite adapters no longer add a default limit of 255 characters on string columns](http://edgeguides.rubyonrails.org/4_2_release_notes.html#active-record-notable-changes).

Nonetheless, I still contend that the artificial limit installed by this gem should be removed.
