### PR TITLE
Replace session ticket generation

### DIFF
--- a/lib/qbwc/session.rb
+++ b/lib/qbwc/session.rb
@@ -18,7 +18,7 @@ class QBWC::Session
     @iterator_id = nil
     @initial_job_count = pending_jobs.length
 
-    @ticket = ticket || Digest::SHA1.hexdigest("#{Rails.application.config.secret_token}#{Time.now.to_i}")
+    @ticket = ticket || Digest::SHA1.hexdigest("#{Rails.application.config.secret_token}#{SecureRandom.uuid}")
 
     @@session = self
     reset(ticket.nil?)


### PR DESCRIPTION
Previously used a hash of a static value and the time in seconds
which is extremely collision prone
Instead use randomly generated GUID. These aren't collision proof
in theory but it's effectively impossibile.

Inspired by https://github.com/qbwc/qbwc/pull/93/ which has been
closed