### PR TITLE
Stephen sullivan patch 1

### DIFF
--- a/lib/generators/qbwc/install/templates/db/migrate/change_request_index.rb
+++ b/lib/generators/qbwc/install/templates/db/migrate/change_request_index.rb
@@ -1,4 +1,4 @@
-class ChangeRequestIndex < ActiveRecord::Migration
+class ChangeRequestIndex < ActiveRecord::Migration[5.1]
   def change
     change_column :qbwc_jobs, :request_index, :text, null: true, default: nil
   end

--- a/lib/generators/qbwc/install/templates/db/migrate/create_qbwc_jobs.rb
+++ b/lib/generators/qbwc/install/templates/db/migrate/create_qbwc_jobs.rb
@@ -1,4 +1,4 @@
-class CreateQbwcJobs < ActiveRecord::Migration
+class CreateQbwcJobs < ActiveRecord::Migration[5.1]
   def change
     create_table :qbwc_jobs, :force => true do |t|
       t.string :name

--- a/lib/generators/qbwc/install/templates/db/migrate/create_qbwc_sessions.rb
+++ b/lib/generators/qbwc/install/templates/db/migrate/create_qbwc_sessions.rb
@@ -1,4 +1,4 @@
-class CreateQbwcSessions < ActiveRecord::Migration
+class CreateQbwcSessions < ActiveRecord::Migration[5.1]
   def change
     create_table :qbwc_sessions, :force => true do |t|
       t.string :ticket

--- a/lib/generators/qbwc/install/templates/db/migrate/index_qbwc_jobs.rb
+++ b/lib/generators/qbwc/install/templates/db/migrate/index_qbwc_jobs.rb
@@ -1,4 +1,4 @@
-class IndexQbwcJobs < ActiveRecord::Migration
+class IndexQbwcJobs < ActiveRecord::Migration[5.1]
   def change
     add_index :qbwc_jobs, :name, unique: true
     add_index :qbwc_jobs, :company, length: 150

--- a/lib/generators/qbwc/install/templates/db/migrate/session_pending_jobs_text.rb
+++ b/lib/generators/qbwc/install/templates/db/migrate/session_pending_jobs_text.rb
@@ -1,4 +1,4 @@
-class SessionPendingJobsText < ActiveRecord::Migration
+class SessionPendingJobsText < ActiveRecord::Migration[5.1]
   def change
     change_column_default(:qbwc_sessions, :pending_jobs, nil)
     change_column :qbwc_sessions, :pending_jobs, :text, :limit => 1000, :null => false


### PR DESCRIPTION
Specified Rails version in migrate classes to avoid error when running `rake db:migrate` in Rails 5.1.