### PR TITLE
Rails 5.1 support - relax wash_out dependency so 0.11.0 can be used

### DIFF
--- a/qbwc.gemspec
+++ b/qbwc.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |s|
   s.add_dependency "qbxml", [">= 0.3.0"]
   
   # 0.10.0 until https://github.com/inossidabile/wash_out/pull/221
-  s.add_dependency "wash_out", ["= 0.10.0"]
+  s.add_dependency "wash_out", [">= 0.10.0"]
   
   s.add_dependency 'actionpack', ['>= 4.1.0']
   


### PR DESCRIPTION
wash_out 0.10.0 includes an around_filter (somewhere, I didn't dig in to find it) - the _filter methods of course have been deprecated in favor of the _action methods - wash_out 0.11.0 works with rails 5.1.

Relaxing the wash_out dependency to allow newer versions lets rails 5.1 users optionally use the newer wash_out. I haven't noticed any downsides or problems with the new version but of course am open to feedback or other ideas on how to resolve the issue.