### PR TITLE
changed current_request to not delete requestID in xml_attributes hash

### DIFF
--- a/lib/qbwc/session.rb
+++ b/lib/qbwc/session.rb
@@ -61,8 +61,8 @@ class QBWC::Session
     request = self.next_request
     if request && self.iterator_id.present?
       request = request.to_hash
-      request.delete('xml_attributes')
-      request.values.first['xml_attributes'] = {'iterator' => 'Continue', 'iteratorID' => self.iterator_id}
+      request.values.first["xml_attributes"].delete_if{|k,v| k != "requestID"}
+      request.values.first['xml_attributes'].merge!({'iterator' => 'Continue', 'iteratorID' => self.iterator_id})
       request = QBWC::Request.new(request)
     end 
     request


### PR DESCRIPTION
I'm sure there's a better way to fix this, but it is really bad to lose the "requestID" for jobs. 

This references issue #124.  