### PR TITLE
Rails 6 uniqueness validator deprecation warning

### DIFF
--- a/lib/qbwc/active_record/job.rb
+++ b/lib/qbwc/active_record/job.rb
@@ -1,6 +1,6 @@
 class QBWC::ActiveRecord::Job < QBWC::Job
   class QbwcJob < ActiveRecord::Base
-    validates :name, :uniqueness => true, :presence => true
+    validates :name, :uniqueness => { :case_sensitive => true }, :presence => true
     serialize :requests, Hash
     serialize :request_index, Hash
     serialize :data


### PR DESCRIPTION
closes #134 Updated uniqueness validation for name on QbwcJob to explicitly validate with `:case_sensitive => true` to fix rails 6 deprecation warning.