### PR TITLE
Fix rails 7.1 deprecation warning

### DIFF
--- a/lib/qbwc/active_record/job.rb
+++ b/lib/qbwc/active_record/job.rb
@@ -1,8 +1,8 @@
 class QBWC::ActiveRecord::Job < QBWC::Job
   class QbwcJob < ActiveRecord::Base
     validates :name, :uniqueness => { :case_sensitive => true }, :presence => true
-    serialize :requests, Hash
-    serialize :request_index, Hash
+    serialize :requests, type: Hash
+    serialize :request_index, type: Hash
     serialize :data
 
     def to_qbwc_job


### PR DESCRIPTION
This fixes the following warning that started appearing when using rails 7.1:

```
DEPRECATION WARNING: Passing the class as positional argument is deprecated and will be removed in Rails 7.2.

Please pass the class as a keyword argument:

  serialize :requests, type: Hash
```