### PR TITLE
Add coder parameter to serialized columns for Rails 7.1

### DIFF
--- a/lib/qbwc.rb
+++ b/lib/qbwc.rb
@@ -70,6 +70,9 @@ module QBWC
   mattr_accessor :log_requests_and_responses
   @@log_requests_and_responses = Rails.env == 'production' ? false : true
 
+  mattr_accessor :default_column_serializer
+  @@default_column_serializer = nil
+
   class << self
 
     def storage_module
@@ -133,6 +136,8 @@ module QBWC
       storage_module::Job.clear_jobs
     end
 
+    def default_column_serializer
+      @@default_column_serializer || Rails.application.config.try(:active_record)&.default_column_serializer || YAML
+    end
   end
-  
 end

--- a/lib/qbwc/active_record/job.rb
+++ b/lib/qbwc/active_record/job.rb
@@ -2,7 +2,10 @@ class QBWC::ActiveRecord::Job < QBWC::Job
   class QbwcJob < ActiveRecord::Base
     validates :name, :uniqueness => { :case_sensitive => true }, :presence => true
 
-    if Rails.version >= '6.1'
+    if Rails.version >= '7.1'
+      serialize :requests, type: Hash, coder: QBWC.default_column_serializer
+      serialize :request_index, type: Hash, coder: QBWC.default_column_serializer
+    elsif Rails.version >= '6.1'
       serialize :requests, type: Hash
       serialize :request_index, type: Hash
     else


### PR DESCRIPTION
Add a config default_column_serializer which will be passed to serialize calls in Rails 7.1 and later. If not set, it will use the value from Rails's active_record.default_column_serializer. If that's not set, then it'll use YAML for backwards compatibility.